### PR TITLE
Merging changes for the 1.3 update

### DIFF
--- a/src/app/changelog/page.tsx
+++ b/src/app/changelog/page.tsx
@@ -43,25 +43,44 @@ const Changelog = () => {
                 <h2 className='text-2xl font-bold mt-10 ml-10 mr-10'>Versions</h2>
                 <Accordion type="single" collapsible className="mt-2 ml-10 mr-10 mb-10" defaultValue="item-0">
                     <AccordionItem value="item-0">
-                        <AccordionTrigger>Version 1.2.1</AccordionTrigger>
+                        <AccordionTrigger>Version 1.3</AccordionTrigger>
                         <AccordionContent>
-                            <p>Version 1.2.1 includes the following changes:
-                                - Bug fixes and performance improvements
-                                - Added the following Children's Zoo Animals:
-                                    - Pygmy Goat
-                                    - Domestic Goat
-                                    - American Alligator
-                                    - North American River Otter
-                                    - African Spurred Tortoise
-                                    - Aldabra Tortoise
-                                    - Florida Red-Bellied Turtle
-                                    - Domestic Rabbit
-                                    - Shetland Sheep
-                                    - Domestic Cat
+                            <p>Version 1.3.0 includes the following changes:
+                                <ul>
+                                    <li> - Added a back button to the animal details page (Thanks Momo & TWGS)</li>
+                                    <li> - Reworked code to make loading faster (just for search + CAT)</li>
+                                    <li> - Added buttons for Rainforest and Australia</li>
+                                    <li> - Fixed Shetland Sheep button not having a photo</li>
+                                </ul>
+                                <br />
+                                **Important for L&E On-Grounds**
+                                Please check to see if loading the 'CAT' section of the app is any faster than before.
                             </p>
                         </AccordionContent>
                     </AccordionItem>
                     <AccordionItem value="item-1">
+                        <AccordionTrigger>Version 1.2.1</AccordionTrigger>
+                        <AccordionContent>
+                            <p>Version 1.2.1 includes the following changes:
+                                <ul>
+                                    <li> - Bug fixes and performance improvements</li>
+                                    <li> - Added the following Children's Zoo Animals:</li>
+                                    <li> - Pygmy Goat</li>
+                                    <li> - Pygmy Goat</li>
+                                    <li> - Domestic Goat</li>
+                                    <li> - American Alligator</li>
+                                    <li> - North American River Otter</li>
+                                    <li> - African Spurred Tortoise</li>
+                                    <li> - Aldabra Tortoise</li>
+                                    <li> - Florida Red-Bellied Turtle</li>
+                                    <li> - Domestic Rabbit</li>
+                                    <li> - Shetland Sheep</li>
+                                    <li> - Domestic Cat</li>
+                                </ul>
+                            </p>
+                        </AccordionContent>
+                    </AccordionItem>
+                    <AccordionItem value="item-2">
                         <AccordionTrigger>Version 1.2.0</AccordionTrigger>
                         <AccordionContent>
                             <p>Version 1.2.0

--- a/src/app/changelog/page.tsx
+++ b/src/app/changelog/page.tsx
@@ -45,14 +45,15 @@ const Changelog = () => {
                     <AccordionItem value="item-0">
                         <AccordionTrigger>Version 1.3</AccordionTrigger>
                         <AccordionContent>
-                            <p>Version 1.3.0 includes the following changes:
-                                <ul>
-                                    <li> - Added a back button to the animal details page (Thanks Momo & TWGS)</li>
-                                    <li> - Reworked code to make loading faster (just for search + CAT)</li>
-                                    <li> - Added buttons for Rainforest and Australia</li>
-                                    <li> - Fixed Shetland Sheep button not having a photo</li>
-                                </ul>
-                                <br />
+                            <p>Version 1.3.0 includes the following changes:</p>
+                            <ul>
+                                <li> - Added a back button to the animal details page (Thanks Momo & TWGS)</li>
+                                <li> - Reworked code to make loading faster (just for search + CAT)</li>
+                                <li> - Added buttons for Rainforest and Australia</li>
+                                <li> - Fixed Shetland Sheep button not having a photo</li>
+                            </ul>
+                            <br />
+                            <p>
                                 **Important for L&E On-Grounds**
                                 Please check to see if loading the 'CAT' section of the app is any faster than before.
                             </p>
@@ -61,23 +62,22 @@ const Changelog = () => {
                     <AccordionItem value="item-1">
                         <AccordionTrigger>Version 1.2.1</AccordionTrigger>
                         <AccordionContent>
-                            <p>Version 1.2.1 includes the following changes:
-                                <ul>
-                                    <li> - Bug fixes and performance improvements</li>
-                                    <li> - Added the following Children's Zoo Animals:</li>
-                                    <li> - Pygmy Goat</li>
-                                    <li> - Pygmy Goat</li>
-                                    <li> - Domestic Goat</li>
-                                    <li> - American Alligator</li>
-                                    <li> - North American River Otter</li>
-                                    <li> - African Spurred Tortoise</li>
-                                    <li> - Aldabra Tortoise</li>
-                                    <li> - Florida Red-Bellied Turtle</li>
-                                    <li> - Domestic Rabbit</li>
-                                    <li> - Shetland Sheep</li>
-                                    <li> - Domestic Cat</li>
-                                </ul>
-                            </p>
+                            <p>Version 1.2.1 includes the following changes:</p>
+                            <ul>
+                                <li> - Bug fixes and performance improvements</li>
+                                <li> - Added the following Children's Zoo Animals:</li>
+                                <li> - Pygmy Goat</li>
+                                <li> - Pygmy Goat</li>
+                                <li> - Domestic Goat</li>
+                                <li> - American Alligator</li>
+                                <li> - North American River Otter</li>
+                                <li> - African Spurred Tortoise</li>
+                                <li> - Aldabra Tortoise</li>
+                                <li> - Florida Red-Bellied Turtle</li>
+                                <li> - Domestic Rabbit</li>
+                                <li> - Shetland Sheep</li>
+                                <li> - Domestic Cat</li>
+                            </ul>
                         </AccordionContent>
                     </AccordionItem>
                     <AccordionItem value="item-2">

--- a/src/app/download/page.tsx
+++ b/src/app/download/page.tsx
@@ -38,10 +38,10 @@ const Download = () => {
                 <Alert className='md:flex justify-between m-5' style={{ maxWidth: '95%' }}>
                     <CircleArrowUpIcon className='m-2' />
                     <div className='ml-5 mt-2 items-center'>
-                        <AlertTitle>Version 1.2.1 is now available!</AlertTitle>
-                        <AlertDescription>Download the latest version of the app to get the latest features and improvements.</AlertDescription>
+                        <AlertTitle>Version 1.3 is now available!</AlertTitle>
+                        <AlertDescription>This version includes major performance improvements! Update to the latest version today!</AlertDescription>
                     </div>
-                    <Link href='https://ozempathyapp.vercel.app/changelog' className={buttonVariants({ variant: "gooeyLeft" })}>Download for iOS</Link>
+                    <Link href='https://ozempathyapp.vercel.app/changelog' className={buttonVariants({ variant: "gooeyLeft" })}>View Changelog</Link>
                 </Alert>
                 <h1 className='text-3xl font-bold mt-5 ml-5 mr-5'>Download the Empathy Guide Mobile App</h1>
                 <p className='text-lg ml-5 mr-5 mt-2 text-gray-600'>Get started by selecting your device from below.</p>
@@ -66,7 +66,7 @@ const Download = () => {
                             <CardDescription>Requires Android 5.0 and up.</CardDescription>
                         </CardContent>
                         <CardFooter>
-                        <Link href='https://drive.google.com/file/d/1zt5UkFq8VBEh3iN43pSw_-yQGsfqD13u/view?usp=drive_link' className={buttonVariants({ variant: "gooeyLeft" })}>Download for Android</Link>
+                        <Link href='https://drive.google.com/file/d/1STML5Q37WVCGsmODj_K7OmLxnJUaEZol/view?usp=drive_link' className={buttonVariants({ variant: "gooeyLeft" })}>Download for Android</Link>
                         </CardFooter>
                     </Card>
                     <Card className='mt-5 transition-all duration-300 ease-in-out transform hover:scale-105 hover:shadow-lg'>


### PR DESCRIPTION
Updated the download page and changelog page to reflect the new 1.3.0 update. Fixed minor typos in the 'view changelog' button displaying as 'download for iOS'